### PR TITLE
修改掉重大顯示問題和部分細節

### DIFF
--- a/prjIHealth/Areas/Admin/Controllers/NewsManageController.cs
+++ b/prjIHealth/Areas/Admin/Controllers/NewsManageController.cs
@@ -55,14 +55,14 @@ namespace prjIHealth.Areas.Admin.Controllers
                 //int datascount = 0;
                 //datascount = datas.Count();
                 //ViewBag.SearchResult = "您搜尋的資料共(" + datascount + ")";
-                if (datas.Count() == 0)
-                {
-                    datas = db.TNews.Include(t => t.FNewsCategory)
-                   .Include(n => n.FMember)
-                   .Select(t => t)
-                   .OrderBy(t => t.FNewsId);
-                    //ViewBag.SearchResult = "沒有您所蒐尋的資料";
-                }
+                //if (datas.Count() == 0)
+                //{
+                //    datas = db.TNews.Include(t => t.FNewsCategory)
+                //   .Include(n => n.FMember)
+                //   .Select(t => t)
+                //   .OrderBy(t => t.FNewsId);
+                //    //ViewBag.SearchResult = "沒有您所蒐尋的資料";
+                //}
                 //.ToPagedList(page ?? 1, 5);
             }
 

--- a/prjIHealth/Areas/Admin/Views/NewsManage/Create.cshtml
+++ b/prjIHealth/Areas/Admin/Views/NewsManage/Create.cshtml
@@ -99,6 +99,9 @@
                 <p>
                     <a asp-action="List" class="site-btn" style="width:150px">返回列表</a>
                 </p>
+                <p>
+                    <a href="https://www.commonhealth.com.tw/blog/4379" target="_blank" id="btnDemo">DEMO網頁</a>
+                </p>
             </div>
         </form>
     </div>
@@ -173,6 +176,10 @@
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
 
     <script>
+        $('#btnDemo').click(() => {
+            $('#FTitle').val("素食腎友更容易貧血？如何從植物食材中補鐵？");
+            $('#FNewsCategoryId').val(2);
+        })
 
         function CheckRequired() {
             if ($('#FTitle').val() == '' || $('#FNewsCategoryId').val() == '' /*|| $('#FContent').text() == ''*/) {

--- a/prjIHealth/Areas/Admin/Views/NewsManage/List.cshtml
+++ b/prjIHealth/Areas/Admin/Views/NewsManage/List.cshtml
@@ -193,6 +193,24 @@
 </section>
 
 @section Scripts{
+
+    @{
+        if (Model.Count() == 0)
+        {
+            <script>
+                SwalGreen.fire({
+                    title: '查無搜尋結果',
+                    text: '請重新輸入查詢關鍵字。',
+                    icon: 'warning',
+                    confirmButtonText: '返回專欄管理',
+                    showCloseButton: true
+                }).then((result) => {
+                    if (result.isConfirmed)
+                        $(location).prop("href", "@Url.Content("~/Admin/NewsManage/List")");
+                })
+            </script>
+        }
+    }
     <script>
         $('#selectCate').on('change', CategoriesChange);
         $('#btnReset').on('click', ResetClick);

--- a/prjIHealth/Controllers/NewsController.cs
+++ b/prjIHealth/Controllers/NewsController.cs
@@ -51,11 +51,14 @@ namespace prjiHealth.Controllers
             var category4Count = db.TNews.Where(t => t.FNewsCategoryId == 4).Count();
             ViewBag.Category4Count = category4Count;
 
+            var countTest = 0;
+
             if (string.IsNullOrEmpty(vModel.txtKeyword))
             {
                 datas = (from t in db.TNews
                          select t).Include(c => c.TNewsComments);
                 onePageOfBlogs = datas.ToPagedList(pageNumber, 6);
+                countTest = datas.ToList().Count();
                 //int datascount = 0;
                 //datascount = datas.Count();
 
@@ -66,16 +69,17 @@ namespace prjiHealth.Controllers
                 datas = db.TNews.Where(t => t.FTitle.Contains(vModel.txtKeyword))
                     .Include(c => c.TNewsComments);
                 onePageOfBlogs = datas.ToPagedList(pageNumber, 6);
+                countTest = datas.ToList().Count();
                 //int datascount = 0;
                 //datascount = datas.Count();
 
                 //ViewBag.SearchResult = "您搜尋的資料共(" + datascount + ")";
-                if (datas.Count() == 0)
-                {
-                    datas = (from t in db.TNews
-                             select t).Include(c => c.TNewsComments);
-                    onePageOfBlogs = datas.ToPagedList(pageNumber, 6);
-                }
+                //if (datas.Count() == 0)
+                //{
+                //    datas = (from t in db.TNews
+                //             select t).Include(c => c.TNewsComments);
+                //    onePageOfBlogs = datas.ToPagedList(pageNumber, 6);
+                //}
             }
             //List<CNewsViewModel> news = new List<CNewsViewModel>();
             //foreach (var n in datas)
@@ -88,14 +92,22 @@ namespace prjiHealth.Controllers
             //    };
             //    news.Add(newsViewModel);
             //}
+            ViewBag.countTest = countTest;
             ViewBag.onePageOfBlogs = onePageOfBlogs;
             return View(onePageOfBlogs);
         }
 
-
-        public IActionResult BlogCategory(int? id)
+        public IActionResult BlogCategory(int? id, CNewsViewModel vModel, int? page)
         {
             IHealthContext db = new IHealthContext();
+            IEnumerable<TNews> datas = null;
+
+            //string noData = "";
+            var pageNumber = page ?? 1;
+            var news = db.TNews.OrderBy(n => n.FNewsId).ToList();
+            var testNews = db.TNews.Include(t => t.FNewsCategory).ToList();
+            var onePageOfBlogs = news.ToPagedList(pageNumber, 6);
+
             var category0Count = db.TNews.Select(t => t).Count();
             ViewBag.Category0Count = category0Count;
             var category1Count = db.TNews.Where(t => t.FNewsCategoryId == 1).Count();
@@ -122,25 +134,109 @@ namespace prjiHealth.Controllers
             {
                 ViewBag.AddClass4 = "selectedCategory";
             }
-            var selCateID = (from n in db.TNews
-                             join c in db.TNewsCategories
-                             on n.FNewsCategoryId equals c.FNewsCategoryId
-                             where n.FNewsCategoryId == id
-            
-                             select new CNewsViewModel()
-                             {
-                                 FNewsId = n.FNewsId,
-                                 FTitle = n.FTitle,
-                                 FNewsDate = n.FNewsDate,
-                                 FContent = n.FContent,
-                                 FThumbnailPath = n.FThumbnailPath,
-                                 FNewsCategoryId = n.FNewsCategoryId,
-                                 FViews = n.FViews,
-                                 FVideoUrl = n.FVideoUrl,
-                                 FMemberId = n.FMemberId,
-                             }).ToList();
-            return View(selCateID);
+
+            if (string.IsNullOrEmpty(vModel.txtKeyword))
+            {
+                datas = (from t in db.TNews.Where(t => t.FNewsCategoryId == id)
+                         select t).Include(c => c.TNewsComments);
+                onePageOfBlogs = datas.ToPagedList(pageNumber, 6);
+                //int datascount = 0;
+                //datascount = datas.Count();
+
+                //ViewBag.SearchResult = "您搜尋的資料共(" + datascount + ")";
+            }
+            else
+            {
+                datas = db.TNews.Where(t => t.FTitle.Contains(vModel.txtKeyword))
+                    .Include(c => c.TNewsComments);
+                onePageOfBlogs = datas.ToPagedList(pageNumber, 6);
+                //int datascount = 0;
+                //datascount = datas.Count();
+
+                ////ViewBag.SearchResult = "您搜尋的資料共(" + datascount + ")";
+                //if (datas.Count() == 0)
+                //{
+                //    noData = "查無此關鍵字";
+                //    datas = (from t in db.TNews.Where(t => t.FNewsCategoryId == id)
+                //             select t).Include(c => c.TNewsComments);
+                //    onePageOfBlogs = datas.ToPagedList(pageNumber, 6);
+                //}
+            }
+            //List<CNewsViewModel> news = new List<CNewsViewModel>();
+            //foreach (var n in datas)
+            //{
+            //    CNewsViewModel newsViewModel = new CNewsViewModel(_db)
+            //    {
+            //        _news = n,
+            //        //newsCategory = n.FNewsCategory,
+            //        //getMember = n.FMember
+            //    };
+            //    news.Add(newsViewModel);
+            //}
+            //ViewBag.NoData = noData;
+            ViewBag.onePageOfBlogs = onePageOfBlogs;
+            return View(onePageOfBlogs);
         }
+
+        //public IActionResult BlogCategory(int? id)
+        //{
+        //    IHealthContext db = new IHealthContext();
+        //    var category0Count = db.TNews.Select(t => t).Count();
+        //    ViewBag.Category0Count = category0Count;
+        //    var category1Count = db.TNews.Where(t => t.FNewsCategoryId == 1).Count();
+        //    ViewBag.Category1Count = category1Count;
+        //    var category2Count = db.TNews.Where(t => t.FNewsCategoryId == 2).Count();
+        //    ViewBag.Category2Count = category2Count;
+        //    var category3Count = db.TNews.Where(t => t.FNewsCategoryId == 3).Count();
+        //    ViewBag.Category3Count = category3Count;
+        //    var category4Count = db.TNews.Where(t => t.FNewsCategoryId == 4).Count();
+        //    ViewBag.Category4Count = category4Count;
+        //    if (id == 1)
+        //    {
+        //        ViewBag.AddClass1 = "selectedCategory";
+        //    }
+        //    if (id == 2)
+        //    {
+        //        ViewBag.AddClass2 = "selectedCategory";
+        //    }
+        //    if (id == 3)
+        //    {
+        //        ViewBag.AddClass3 = "selectedCategory";
+        //    }
+        //    if (id == 4)
+        //    {
+        //        ViewBag.AddClass4 = "selectedCategory";
+        //    }
+        //    var selCateID = (from n in db.TNews
+        //                     join c in db.TNewsCategories
+        //                     on n.FNewsCategoryId equals c.FNewsCategoryId
+        //                     where n.FNewsCategoryId == id
+        //                     select new TNews()
+        //                     {
+        //                         FNewsId = n.FNewsId,
+        //                         FTitle = n.FTitle,
+        //                         FNewsDate = n.FNewsDate,
+        //                         FContent = n.FContent,
+        //                         FThumbnailPath = n.FThumbnailPath,
+        //                         FNewsCategoryId = n.FNewsCategoryId,
+        //                         FViews = n.FViews,
+        //                         FVideoUrl = n.FVideoUrl,
+        //                         FMemberId = n.FMemberId,
+        //                     }).ToList();
+        //    //List<CNewsViewModel> news = new List<CNewsViewModel>();
+        //    //foreach (var n in datas)
+        //    //{
+        //    //    CNewsViewModel newsViewModel = new CNewsViewModel(_db)
+        //    //    {
+        //    //        _news = n,
+        //    //        //newsCategory = n.FNewsCategory,
+        //    //        //getMember = n.FMember
+        //    //    };
+        //    //    news.Add(newsViewModel);
+        //    //}
+
+        //    return View(selCateID);
+        //}
 
         public IActionResult BlogDetail(int? id)
         {
@@ -192,7 +288,7 @@ namespace prjiHealth.Controllers
         public IActionResult BlogSelectCategoryAPI(int? id)
         {
             IHealthContext db = new IHealthContext();
-            
+
             if (id == null)
             {
                 var selCateID = db.TNews.Include(c => c.TNewsComments).OrderBy(t => t.FNewsId).Select(t => new
@@ -208,7 +304,7 @@ namespace prjiHealth.Controllers
             }
             else
             {
-                var selCateID = db.TNews.Include(c => c.TNewsComments).Where(t => t.FNewsCategoryId == id).OrderBy(t => t.FNewsId).Select(t=>new
+                var selCateID = db.TNews.Include(c => c.TNewsComments).Where(t => t.FNewsCategoryId == id).OrderBy(t => t.FNewsId).Select(t => new
                 {
                     t.FNewsId,
                     t.FThumbnailPath,
@@ -219,7 +315,6 @@ namespace prjiHealth.Controllers
                 });
                 return Json(selCateID);
             }
-            
         }
 
         public IActionResult LoadComment(int id)

--- a/prjIHealth/Views/News/Blog.cshtml
+++ b/prjIHealth/Views/News/Blog.cshtml
@@ -1,6 +1,6 @@
 ﻿@model System.Collections.Generic.IEnumerable<prjIHealth.Models.TNews>
-    @using X.PagedList
-    @using X.PagedList.Mvc.Core
+@using X.PagedList
+@using X.PagedList.Mvc.Core
 @*@model List<prjiHealth.ViewModels.CNewsViewModel>*@
 
 @section Styles{
@@ -29,7 +29,7 @@
     </style>
 
 }
-@*<link rel="stylesheet" href="/css/ShoppingMallCategory.css" type="text/css">*@
+<link rel="stylesheet" href="/css/ShoppingMallCategory.css" type="text/css">
 
 <!-- Breadcrumb Section Begin -->
 <section class="breadcrumb-section set-bg" data-setbg="/img/blog/banner_news.png" id="bannerTop">
@@ -62,7 +62,7 @@
                             <button type="submit"><span class="icon_search"></span></button>
                         </form>
                         <br />
-                        <label id="divcount">共 @Model.Count() 筆資料</label>
+                        @*<label id="divcount">共 @Model.Count() 筆資料</label>*@
                     </div>
                     <div class="blog__sidebar__item" id="cateSe">
                         <h4>專欄分類</h4>
@@ -159,6 +159,25 @@
 <!-- Blog Section End -->
 
 @section Scripts{
+
+    @{
+        if (Model.Count() == 0)
+        {
+
+            <script>
+                SwalGreen.fire({
+                    title: '查無搜尋結果',
+                    text: '請重新輸入查詢關鍵字。',
+                    icon: 'warning',
+                    confirmButtonText: '前往健康資訊',
+                    showCloseButton: true
+                }).then((result) => {
+                    if (result.isConfirmed)
+                        $(location).prop("href", "@Url.Content("~/News/Blog")");
+                })
+            </script>
+        }
+    }
     <script>
 
         $('#cate').on('click', CategorySelect)
@@ -242,7 +261,7 @@
         //function GetPage() {
         //    $(".blog__pagination").empty();
         //    let newsCount = $("#BlogShow").children(".aNews").length;
-            
+
         //    let pageCount = newsCount / 6;
         //    for (let i = 1; i < pageCount + 1; i++) {
         //        $(".blog__pagination").append(`<button class="btnPage" id="btn${i}">${i}</button>`);

--- a/prjIHealth/Views/News/BlogCategory.cshtml
+++ b/prjIHealth/Views/News/BlogCategory.cshtml
@@ -1,5 +1,6 @@
 ﻿@model System.Collections.Generic.IEnumerable<prjIHealth.Models.TNews>
-
+@using X.PagedList
+@using X.PagedList.Mvc.Core
 
 @section Styles{
     <link href="/css/PagedList.css" rel="stylesheet" />
@@ -40,7 +41,7 @@
                     <div class="blog__sidebar__item" id="cateSe">
                         <h4>專欄分類</h4>
                         <ul id="cate">
-                            <li><a href="~/News/Blog"　class="categoryItem">所有顯示 (@ViewBag.Category0Count)</a></li>
+                            <li><a href="~/News/Blog" 　class="categoryItem">所有顯示 (@ViewBag.Category0Count)</a></li>
                             <li><a data-id="1" class="categoryItem @ViewBag.AddClass1">運動健身 (@ViewBag.Category1Count)</a></li>
                             <li><a data-id="2" class="categoryItem @ViewBag.AddClass2">食物營養 (@ViewBag.Category2Count)</a></li>
                             <li><a data-id="3" class="categoryItem @ViewBag.AddClass3">新冠疫情 (@ViewBag.Category3Count)</a></li>
@@ -121,6 +122,7 @@
                     @*BLOG專欄一覽位置*@
                     <div class="col-lg-12">
                         <div class="product__pagination blog__pagination">
+                            @Html.PagedListPager((IPagedList)ViewBag.onePageOfBlogs, page => Url.Action("Blog", new { page }))
                         </div>
                     </div>
                 </div>
@@ -131,6 +133,26 @@
 <!-- Blog Section End -->
 
 @section Scripts{
+
+    @{
+        if (Model.Count() == 0)
+        {
+
+            <script>
+                SwalGreen.fire({
+                    title: '查無搜尋結果',
+                    text: '請重新輸入查詢關鍵字。',
+                    icon: 'warning',
+                    confirmButtonText: '前往健康資訊',
+                    showCloseButton: true
+                }).then((result) => {
+                    if (result.isConfirmed)
+                        $(location).prop("href", "@Url.Content("~/News/Blog")");
+                })
+            </script>
+        }
+    }
+
     <script>
 
         $('#cate').on('click', CategorySelect)

--- a/prjIHealth/Views/News/BlogDetail.cshtml
+++ b/prjIHealth/Views/News/BlogDetail.cshtml
@@ -127,7 +127,7 @@
                     <img src="~/img/blog/@Model.FThumbnailPath" alt="">
                     <input type="hidden" data-id="@Model.FNewsId" value="@Model.FNewsId" name="NewsId" id="blodNewsId" />
                     <p>
-                        @Html.Raw(@Model.FContent)
+                        @Html.Raw(@Model.FContent.Replace("廣告", ""))
                     </p>
 
                     @*<div id="divReplyPartial">*@


### PR DESCRIPTION
修改Controller的搜尋邏輯判斷問題，拔到後端判斷
新增Create DEMO演示用跳出視窗
修改List搜尋不到內容，改為前端彈出提示

前端
修改BlogCategory突然跳出轉型問題，修改成為定型態
修改不曉得為何被註解掉的css樣式，搜尋結果改為前端判斷跳出提示
新增BlogCategory頁碼格式和套件
修改BlogDetail如果有獨到廣告字串直接更改為空白

_S